### PR TITLE
[#9] feat: implement local ledger final settlement with retry scheduler and epoch settlement fields

### DIFF
--- a/clearing-hub/build.gradle
+++ b/clearing-hub/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
+	implementation 'org.web3j:core:4.12.3'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/clearing-hub/src/main/java/com/austinhong22/krwstablehub/api/epoch/dto/EpochDetailResponse.java
+++ b/clearing-hub/src/main/java/com/austinhong22/krwstablehub/api/epoch/dto/EpochDetailResponse.java
@@ -10,17 +10,12 @@ public record EpochDetailResponse(
         Instant openedAt,
         Instant closedAt,
         List<NetPositionItem> netPositions,
-        SettlementInstructionItem settlementInstruction
+        String settlementStatus,
+        String txHash
 ) {
     public record NetPositionItem(
             String participantCode,
             long netAmountKrw
-    ) {
-    }
-
-    public record SettlementInstructionItem(
-            String status,
-            String txHash
     ) {
     }
 }

--- a/clearing-hub/src/main/java/com/austinhong22/krwstablehub/infra/ledger/SettlementLedgerClient.java
+++ b/clearing-hub/src/main/java/com/austinhong22/krwstablehub/infra/ledger/SettlementLedgerClient.java
@@ -1,0 +1,172 @@
+package com.austinhong22.krwstablehub.infra.ledger;
+
+import com.example.clearinghub.infra.ledger.LedgerProperties;
+import jakarta.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.web3j.abi.EventEncoder;
+import org.web3j.abi.FunctionEncoder;
+import org.web3j.abi.TypeReference;
+import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.DynamicArray;
+import org.web3j.abi.datatypes.Event;
+import org.web3j.abi.datatypes.Function;
+import org.web3j.abi.datatypes.generated.Int256;
+import org.web3j.abi.datatypes.generated.Uint256;
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.methods.response.EthGasPrice;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.protocol.core.methods.response.Log;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.http.HttpService;
+import org.web3j.tx.RawTransactionManager;
+import org.web3j.tx.response.PollingTransactionReceiptProcessor;
+import org.web3j.tx.response.TransactionReceiptProcessor;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+
+@Component
+public class SettlementLedgerClient {
+
+    private static final String FUNCTION_SETTLE = "settle";
+    private static final Event SETTLED_EVENT = new Event(
+            "Settled",
+            List.of(new TypeReference<Uint256>(true) {
+            })
+    );
+    private static final String SETTLED_EVENT_TOPIC = EventEncoder.encode(SETTLED_EVENT);
+    private static final BigInteger FALLBACK_GAS_PRICE = BigInteger.valueOf(1_000_000_000L);
+    private static final int RECEIPT_POLL_INTERVAL_MILLIS = 1000;
+    private static final int RECEIPT_ATTEMPTS = 60;
+
+    private final LedgerProperties ledgerProperties;
+    private final Web3j web3j;
+
+    public SettlementLedgerClient(LedgerProperties ledgerProperties) {
+        this.ledgerProperties = ledgerProperties;
+        this.web3j = Web3j.build(new HttpService(ledgerProperties.rpcUrl()));
+    }
+
+    public String settle(long epochId, List<String> participantAddresses, List<Long> deltasKrw) {
+        if (participantAddresses.size() != deltasKrw.size()) {
+            throw new IllegalArgumentException("participants and deltas length mismatch");
+        }
+
+        String contractAddress = requireConfigured(ledgerProperties.contractAddress(), "ledger.contract-address");
+        String operatorPrivateKey = requireConfigured(ledgerProperties.operatorPrivateKey(), "ledger.operator-private-key");
+        Credentials credentials = Credentials.create(operatorPrivateKey);
+
+        Function function = new Function(
+                FUNCTION_SETTLE,
+                List.of(
+                        new Uint256(BigInteger.valueOf(epochId)),
+                        new DynamicArray<>(
+                                Address.class,
+                                participantAddresses.stream().map(Address::new).toList()
+                        ),
+                        new DynamicArray<>(
+                                Int256.class,
+                                deltasKrw.stream().map(value -> new Int256(BigInteger.valueOf(value))).toList()
+                        )
+                ),
+                List.of()
+        );
+
+        String encodedFunction = FunctionEncoder.encode(function);
+        BigInteger gasPrice = resolveGasPrice();
+        BigInteger gasLimit = BigInteger.valueOf(ledgerProperties.gasLimit());
+
+        RawTransactionManager transactionManager =
+                new RawTransactionManager(web3j, credentials, ledgerProperties.chainId());
+        EthSendTransaction sent = sendTransaction(transactionManager, gasPrice, gasLimit, contractAddress, encodedFunction);
+        if (sent.hasError()) {
+            throw new IllegalStateException("ledger transaction rejected: " + sent.getError().getMessage());
+        }
+
+        String txHash = sent.getTransactionHash();
+        TransactionReceipt receipt = waitForReceipt(txHash);
+        if (!receipt.isStatusOK()) {
+            throw new IllegalStateException("ledger transaction failed: " + txHash);
+        }
+        if (!containsSettledEvent(receipt, contractAddress)) {
+            throw new IllegalStateException("ledger transaction missing Settled event: " + txHash);
+        }
+
+        return txHash;
+    }
+
+    private EthSendTransaction sendTransaction(
+            RawTransactionManager transactionManager,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String contractAddress,
+            String encodedFunction
+    ) {
+        try {
+            return transactionManager.sendTransaction(gasPrice, gasLimit, contractAddress, encodedFunction, BigInteger.ZERO);
+        } catch (IOException exception) {
+            throw new IllegalStateException("failed to send ledger transaction", exception);
+        }
+    }
+
+    private TransactionReceipt waitForReceipt(String txHash) {
+        TransactionReceiptProcessor processor = new PollingTransactionReceiptProcessor(
+                web3j,
+                RECEIPT_POLL_INTERVAL_MILLIS,
+                RECEIPT_ATTEMPTS
+        );
+        try {
+            return processor.waitForTransactionReceipt(txHash);
+        } catch (IOException exception) {
+            throw new IllegalStateException("failed to fetch ledger receipt", exception);
+        } catch (org.web3j.protocol.exceptions.TransactionException exception) {
+            throw new IllegalStateException("timed out waiting for ledger receipt", exception);
+        }
+    }
+
+    private BigInteger resolveGasPrice() {
+        if (ledgerProperties.gasPrice() > 0) {
+            return BigInteger.valueOf(ledgerProperties.gasPrice());
+        }
+        try {
+            EthGasPrice response = web3j.ethGasPrice().send();
+            BigInteger gasPrice = response.getGasPrice();
+            if (gasPrice != null && gasPrice.signum() > 0) {
+                return gasPrice;
+            }
+            return FALLBACK_GAS_PRICE;
+        } catch (IOException exception) {
+            throw new IllegalStateException("failed to resolve gas price", exception);
+        }
+    }
+
+    private boolean containsSettledEvent(TransactionReceipt receipt, String contractAddress) {
+        for (Log log : receipt.getLogs()) {
+            if (!contractAddress.equalsIgnoreCase(log.getAddress())) {
+                continue;
+            }
+            if (log.getTopics() == null || log.getTopics().isEmpty()) {
+                continue;
+            }
+            if (SETTLED_EVENT_TOPIC.equalsIgnoreCase(log.getTopics().get(0))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String requireConfigured(String value, String propertyName) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalStateException("missing required property: " + propertyName);
+        }
+        return value;
+    }
+
+    @PreDestroy
+    void shutdownClient() {
+        web3j.shutdown();
+    }
+}

--- a/clearing-hub/src/main/java/com/austinhong22/krwstablehub/service/EpochQueryService.java
+++ b/clearing-hub/src/main/java/com/austinhong22/krwstablehub/service/EpochQueryService.java
@@ -38,7 +38,8 @@ public class EpochQueryService {
                 epoch.getOpenedAt(),
                 epoch.getClosedAt(),
                 mapPositions(positions),
-                mapSettlementInstruction(settlementInstruction)
+                settlementInstruction == null ? null : settlementInstruction.getStatus().name(),
+                settlementInstruction == null ? null : settlementInstruction.getTxHash()
         );
     }
 
@@ -51,13 +52,4 @@ public class EpochQueryService {
                 .toList();
     }
 
-    private EpochDetailResponse.SettlementInstructionItem mapSettlementInstruction(SettlementInstructionEntity instruction) {
-        if (instruction == null) {
-            return null;
-        }
-        return new EpochDetailResponse.SettlementInstructionItem(
-                instruction.getStatus().name(),
-                instruction.getTxHash()
-        );
-    }
 }

--- a/clearing-hub/src/main/java/com/austinhong22/krwstablehub/service/SettlementProcessor.java
+++ b/clearing-hub/src/main/java/com/austinhong22/krwstablehub/service/SettlementProcessor.java
@@ -1,0 +1,212 @@
+package com.austinhong22.krwstablehub.service;
+
+import com.austinhong22.krwstablehub.infra.ledger.SettlementLedgerClient;
+import com.austinhong22.krwstablehub.persistence.model.EpochEntity;
+import com.austinhong22.krwstablehub.persistence.model.EpochStatus;
+import com.austinhong22.krwstablehub.persistence.model.NetPositionEntity;
+import com.austinhong22.krwstablehub.persistence.model.OutboxEventEntity;
+import com.austinhong22.krwstablehub.persistence.model.SettlementInstructionEntity;
+import com.austinhong22.krwstablehub.persistence.model.SettlementStatus;
+import com.austinhong22.krwstablehub.persistence.repository.EpochRepository;
+import com.austinhong22.krwstablehub.persistence.repository.NetPositionRepository;
+import com.austinhong22.krwstablehub.persistence.repository.OutboxEventRepository;
+import com.austinhong22.krwstablehub.persistence.repository.SettlementInstructionRepository;
+import com.example.clearinghub.config.ClearingProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SettlementProcessor {
+
+    private static final Duration RETRY_DELAY = Duration.ofSeconds(5);
+    private static final int MAX_LAST_ERROR_LENGTH = 2000;
+    private static final String OUTBOX_STATUS_PENDING = "PENDING";
+    private static final String OUTBOX_AGGREGATE_TYPE_EPOCH = "EPOCH";
+    private static final String OUTBOX_EVENT_TYPE_SETTLED = "EPOCH_SETTLED";
+
+    private final SettlementInstructionRepository settlementInstructionRepository;
+    private final EpochRepository epochRepository;
+    private final NetPositionRepository netPositionRepository;
+    private final OutboxEventRepository outboxEventRepository;
+    private final SettlementLedgerClient settlementLedgerClient;
+    private final ClearingProperties clearingProperties;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public List<Long> findPendingInstructionIds(Instant now) {
+        int batchSize = requireBatchSize();
+        List<Long> instructionIds = new ArrayList<>(batchSize);
+
+        List<SettlementInstructionEntity> created = settlementInstructionRepository.findByStatusOrderByIdAsc(
+                SettlementStatus.CREATED,
+                PageRequest.of(0, batchSize)
+        );
+        for (SettlementInstructionEntity instruction : created) {
+            instructionIds.add(instruction.getId());
+        }
+
+        int remaining = batchSize - instructionIds.size();
+        if (remaining <= 0) {
+            return instructionIds;
+        }
+
+        List<SettlementInstructionEntity> retrying = settlementInstructionRepository.findByStatusAndNextRetryAtLessThanEqualOrderByIdAsc(
+                SettlementStatus.RETRYING,
+                now,
+                PageRequest.of(0, remaining)
+        );
+        for (SettlementInstructionEntity instruction : retrying) {
+            instructionIds.add(instruction.getId());
+        }
+        return instructionIds;
+    }
+
+    @Transactional
+    public void processInstruction(Long instructionId) {
+        Instant now = Instant.now();
+        SettlementInstructionEntity instruction = settlementInstructionRepository.findByIdForUpdate(instructionId).orElse(null);
+        if (instruction == null || !isProcessable(instruction, now)) {
+            return;
+        }
+
+        EpochEntity epoch = epochRepository.findByIdForUpdate(instruction.getEpoch().getId()).orElseThrow(
+                () -> new IllegalStateException("Epoch not found for settlement instruction " + instructionId)
+        );
+        if (epoch.getStatus() != EpochStatus.NETTED) {
+            return;
+        }
+
+        int maxAttempts = requireMaxAttempts();
+        int nextAttempt = instruction.getAttemptCount() + 1;
+        instruction.setAttemptCount(nextAttempt);
+        if (nextAttempt > maxAttempts) {
+            instruction.setStatus(SettlementStatus.FAILED);
+            instruction.setNextRetryAt(null);
+            instruction.setLastError("Max settlement attempts exceeded");
+            epoch.setStatus(EpochStatus.FAILED);
+            return;
+        }
+
+        instruction.setStatus(SettlementStatus.RETRYING);
+        instruction.setNextRetryAt(null);
+        instruction.setLastError(null);
+        settlementInstructionRepository.saveAndFlush(instruction);
+
+        List<NetPositionEntity> netPositions = netPositionRepository.findByEpochIdOrderByIdAsc(epoch.getId());
+        Map<Long, String> ledgerAddressByParticipantId = mapLedgerAddressByParticipantId(netPositions);
+        List<String> participants = new ArrayList<>(netPositions.size());
+        List<Long> deltas = new ArrayList<>(netPositions.size());
+        for (NetPositionEntity position : netPositions) {
+            Long participantId = position.getParticipant().getId();
+            String ledgerAddress = ledgerAddressByParticipantId.get(participantId);
+            if (!StringUtils.hasText(ledgerAddress)) {
+                throw new IllegalStateException("Missing ledger address for participant " + participantId);
+            }
+            participants.add(ledgerAddress);
+            deltas.add(position.getNetAmountKrw());
+        }
+
+        try {
+            String txHash = settlementLedgerClient.settle(epoch.getId(), participants, deltas);
+            instruction.setStatus(SettlementStatus.SETTLED);
+            instruction.setTxHash(txHash);
+            instruction.setNextRetryAt(null);
+            instruction.setLastError(null);
+
+            epoch.setStatus(EpochStatus.SETTLED);
+            outboxEventRepository.save(buildSettledOutboxEvent(epoch.getId(), txHash, now));
+        } catch (Exception exception) {
+            instruction.setLastError(truncateError(exception));
+            if (instruction.getAttemptCount() >= maxAttempts) {
+                instruction.setStatus(SettlementStatus.FAILED);
+                instruction.setNextRetryAt(null);
+                epoch.setStatus(EpochStatus.FAILED);
+            } else {
+                instruction.setStatus(SettlementStatus.RETRYING);
+                instruction.setNextRetryAt(now.plus(RETRY_DELAY));
+            }
+            log.warn("Settlement attempt failed for instructionId={}", instructionId, exception);
+        }
+    }
+
+    private Map<Long, String> mapLedgerAddressByParticipantId(List<NetPositionEntity> netPositions) {
+        Map<Long, String> addresses = new LinkedHashMap<>();
+        for (NetPositionEntity netPosition : netPositions) {
+            addresses.put(netPosition.getParticipant().getId(), netPosition.getParticipant().getLedgerAddress());
+        }
+        return addresses;
+    }
+
+    private OutboxEventEntity buildSettledOutboxEvent(Long epochId, String txHash, Instant now) {
+        OutboxEventEntity outboxEvent = new OutboxEventEntity();
+        outboxEvent.setAggregateType(OUTBOX_AGGREGATE_TYPE_EPOCH);
+        outboxEvent.setAggregateId(epochId);
+        outboxEvent.setEventType(OUTBOX_EVENT_TYPE_SETTLED);
+        outboxEvent.setPayloadJson(payloadJson(epochId, txHash, now));
+        outboxEvent.setStatus(OUTBOX_STATUS_PENDING);
+        outboxEvent.setAvailableAt(now);
+        return outboxEvent;
+    }
+
+    private String payloadJson(Long epochId, String txHash, Instant now) {
+        try {
+            return objectMapper.createObjectNode()
+                    .put("epochId", epochId)
+                    .put("txHash", txHash)
+                    .put("settledAt", now.toString())
+                    .toString();
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to build settlement outbox payload", exception);
+        }
+    }
+
+    private String truncateError(Exception exception) {
+        String message = exception.getMessage();
+        if (!StringUtils.hasText(message)) {
+            message = exception.getClass().getSimpleName();
+        }
+        if (message.length() <= MAX_LAST_ERROR_LENGTH) {
+            return message;
+        }
+        return message.substring(0, MAX_LAST_ERROR_LENGTH);
+    }
+
+    private boolean isProcessable(SettlementInstructionEntity instruction, Instant now) {
+        if (instruction.getStatus() == SettlementStatus.CREATED) {
+            return true;
+        }
+        return instruction.getStatus() == SettlementStatus.RETRYING
+                && instruction.getNextRetryAt() != null
+                && !instruction.getNextRetryAt().isAfter(now);
+    }
+
+    private int requireBatchSize() {
+        int batchSize = clearingProperties.settlement().batchSize();
+        if (batchSize <= 0) {
+            throw new IllegalStateException("clearing.settlement.batch-size must be greater than 0");
+        }
+        return batchSize;
+    }
+
+    private int requireMaxAttempts() {
+        int maxAttempts = clearingProperties.settlement().maxAttempts();
+        if (maxAttempts <= 0) {
+            throw new IllegalStateException("clearing.settlement.max-attempts must be greater than 0");
+        }
+        return maxAttempts;
+    }
+}

--- a/clearing-hub/src/main/java/com/austinhong22/krwstablehub/service/SettlementScheduler.java
+++ b/clearing-hub/src/main/java/com/austinhong22/krwstablehub/service/SettlementScheduler.java
@@ -1,0 +1,29 @@
+package com.austinhong22.krwstablehub.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SettlementScheduler {
+
+    private final SettlementProcessor settlementProcessor;
+
+    @Scheduled(fixedDelay = 1000L)
+    public void processPendingSettlements() {
+        List<Long> instructionIds = settlementProcessor.findPendingInstructionIds(Instant.now());
+        for (Long instructionId : instructionIds) {
+            try {
+                settlementProcessor.processInstruction(instructionId);
+            } catch (Exception exception) {
+                log.error("Unexpected error processing settlement instructionId={}", instructionId, exception);
+            }
+        }
+    }
+}

--- a/clearing-hub/src/test/java/com/austinhong22/krwstablehub/KrwstablehubApplicationTests.java
+++ b/clearing-hub/src/test/java/com/austinhong22/krwstablehub/KrwstablehubApplicationTests.java
@@ -5,6 +5,7 @@ import com.austinhong22.krwstablehub.service.EpochCloseService;
 import com.austinhong22.krwstablehub.service.EpochQueryService;
 import com.austinhong22.krwstablehub.service.NettingService;
 import com.austinhong22.krwstablehub.service.ObligationService;
+import com.austinhong22.krwstablehub.service.SettlementProcessor;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -26,6 +27,9 @@ class KrwstablehubApplicationTests {
 
 	@MockitoBean
 	private EpochQueryService epochQueryService;
+
+	@MockitoBean
+	private SettlementProcessor settlementProcessor;
 
 	@Test
 	void contextLoads() {

--- a/clearing-hub/src/test/java/com/austinhong22/krwstablehub/service/EpochQueryServiceTest.java
+++ b/clearing-hub/src/test/java/com/austinhong22/krwstablehub/service/EpochQueryServiceTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,7 +53,7 @@ class EpochQueryServiceTest {
         SettlementInstructionEntity instruction = new SettlementInstructionEntity();
         instruction.setEpoch(epoch);
         instruction.setStatus(SettlementStatus.CREATED);
-        instruction.setTxHash(null);
+        instruction.setTxHash("0xdeadbeef");
 
         when(epochRepository.findById(10L)).thenReturn(Optional.of(epoch));
         when(netPositionRepository.findByEpochIdOrderByIdAsc(10L)).thenReturn(List.of(a, b));
@@ -67,8 +66,8 @@ class EpochQueryServiceTest {
         assertEquals(2, response.netPositions().size());
         assertEquals("A", response.netPositions().get(0).participantCode());
         assertEquals(-70L, response.netPositions().get(0).netAmountKrw());
-        assertNotNull(response.settlementInstruction());
-        assertEquals("CREATED", response.settlementInstruction().status());
+        assertEquals("CREATED", response.settlementStatus());
+        assertEquals("0xdeadbeef", response.txHash());
     }
 
     private NetPositionEntity netPosition(EpochEntity epoch, ParticipantEntity participant, long amountKrw) {

--- a/clearing-hub/src/test/java/com/austinhong22/krwstablehub/service/SettlementProcessorTest.java
+++ b/clearing-hub/src/test/java/com/austinhong22/krwstablehub/service/SettlementProcessorTest.java
@@ -1,0 +1,225 @@
+package com.austinhong22.krwstablehub.service;
+
+import com.austinhong22.krwstablehub.infra.ledger.SettlementLedgerClient;
+import com.austinhong22.krwstablehub.persistence.model.EpochEntity;
+import com.austinhong22.krwstablehub.persistence.model.EpochStatus;
+import com.austinhong22.krwstablehub.persistence.model.NetPositionEntity;
+import com.austinhong22.krwstablehub.persistence.model.OutboxEventEntity;
+import com.austinhong22.krwstablehub.persistence.model.ParticipantEntity;
+import com.austinhong22.krwstablehub.persistence.model.SettlementInstructionEntity;
+import com.austinhong22.krwstablehub.persistence.model.SettlementStatus;
+import com.austinhong22.krwstablehub.persistence.repository.EpochRepository;
+import com.austinhong22.krwstablehub.persistence.repository.NetPositionRepository;
+import com.austinhong22.krwstablehub.persistence.repository.OutboxEventRepository;
+import com.austinhong22.krwstablehub.persistence.repository.SettlementInstructionRepository;
+import com.example.clearinghub.config.ClearingProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementProcessorTest {
+
+    @Mock
+    private SettlementInstructionRepository settlementInstructionRepository;
+
+    @Mock
+    private EpochRepository epochRepository;
+
+    @Mock
+    private NetPositionRepository netPositionRepository;
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    @Mock
+    private SettlementLedgerClient settlementLedgerClient;
+
+    private SettlementProcessor settlementProcessor;
+
+    @BeforeEach
+    void setUp() {
+        ClearingProperties properties = new ClearingProperties(
+                new ClearingProperties.Epoch(60L),
+                new ClearingProperties.Settlement(3, 4)
+        );
+        settlementProcessor = new SettlementProcessor(
+                settlementInstructionRepository,
+                epochRepository,
+                netPositionRepository,
+                outboxEventRepository,
+                settlementLedgerClient,
+                properties,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    void shouldFindCreatedThenDueRetryingInstructions() {
+        SettlementInstructionEntity created = instruction(1L, SettlementStatus.CREATED, 0, null);
+        SettlementInstructionEntity retrying = instruction(2L, SettlementStatus.RETRYING, 1, Instant.now().minusSeconds(1));
+
+        when(settlementInstructionRepository.findByStatusOrderByIdAsc(eq(SettlementStatus.CREATED), any(Pageable.class)))
+                .thenReturn(List.of(created));
+        when(settlementInstructionRepository.findByStatusAndNextRetryAtLessThanEqualOrderByIdAsc(
+                eq(SettlementStatus.RETRYING),
+                any(Instant.class),
+                any(Pageable.class)
+        )).thenReturn(List.of(retrying));
+
+        List<Long> ids = settlementProcessor.findPendingInstructionIds(Instant.now());
+
+        assertEquals(List.of(1L, 2L), ids);
+    }
+
+    @Test
+    void shouldSettleInstructionAndCreateOutbox() {
+        EpochEntity epoch = epoch(10L, EpochStatus.NETTED);
+        SettlementInstructionEntity instruction = instruction(100L, SettlementStatus.CREATED, 0, null);
+        instruction.setEpoch(epoch);
+
+        List<NetPositionEntity> positions = List.of(
+                netPosition(epoch, participant(1L, "0x1111111111111111111111111111111111111111"), -70L),
+                netPosition(epoch, participant(2L, "0x2222222222222222222222222222222222222222"), 70L)
+        );
+
+        when(settlementInstructionRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(instruction));
+        when(epochRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(epoch));
+        when(netPositionRepository.findByEpochIdOrderByIdAsc(10L)).thenReturn(positions);
+        when(settlementLedgerClient.settle(
+                eq(10L),
+                eq(List.of("0x1111111111111111111111111111111111111111", "0x2222222222222222222222222222222222222222")),
+                eq(List.of(-70L, 70L))
+        )).thenReturn("0xabc");
+
+        settlementProcessor.processInstruction(100L);
+
+        assertEquals(1, instruction.getAttemptCount());
+        assertEquals(SettlementStatus.SETTLED, instruction.getStatus());
+        assertEquals("0xabc", instruction.getTxHash());
+        assertNull(instruction.getLastError());
+        assertNull(instruction.getNextRetryAt());
+        assertEquals(EpochStatus.SETTLED, epoch.getStatus());
+
+        ArgumentCaptor<OutboxEventEntity> outboxCaptor = ArgumentCaptor.forClass(OutboxEventEntity.class);
+        verify(outboxEventRepository).save(outboxCaptor.capture());
+        OutboxEventEntity event = outboxCaptor.getValue();
+        assertEquals("EPOCH", event.getAggregateType());
+        assertEquals(10L, event.getAggregateId());
+        assertEquals("EPOCH_SETTLED", event.getEventType());
+        assertEquals("PENDING", event.getStatus());
+        assertNotNull(event.getAvailableAt());
+        assertTrue(event.getPayloadJson().contains("\"txHash\":\"0xabc\""));
+
+        InOrder order = inOrder(settlementInstructionRepository, settlementLedgerClient);
+        order.verify(settlementInstructionRepository).saveAndFlush(instruction);
+        order.verify(settlementLedgerClient).settle(
+                eq(10L),
+                eq(List.of("0x1111111111111111111111111111111111111111", "0x2222222222222222222222222222222222222222")),
+                eq(List.of(-70L, 70L))
+        );
+    }
+
+    @Test
+    void shouldKeepRetryingWhenLedgerCallFails() {
+        EpochEntity epoch = epoch(11L, EpochStatus.NETTED);
+        SettlementInstructionEntity instruction = instruction(101L, SettlementStatus.CREATED, 0, null);
+        instruction.setEpoch(epoch);
+
+        when(settlementInstructionRepository.findByIdForUpdate(101L)).thenReturn(Optional.of(instruction));
+        when(epochRepository.findByIdForUpdate(11L)).thenReturn(Optional.of(epoch));
+        when(netPositionRepository.findByEpochIdOrderByIdAsc(11L)).thenReturn(List.of(
+                netPosition(epoch, participant(1L, "0x1111111111111111111111111111111111111111"), 0L)
+        ));
+        when(settlementLedgerClient.settle(eq(11L), org.mockito.ArgumentMatchers.<List<String>>any(), org.mockito.ArgumentMatchers.<List<Long>>any()))
+                .thenThrow(new IllegalStateException("ledger offline"));
+
+        settlementProcessor.processInstruction(101L);
+
+        assertEquals(1, instruction.getAttemptCount());
+        assertEquals(SettlementStatus.RETRYING, instruction.getStatus());
+        assertNotNull(instruction.getNextRetryAt());
+        assertTrue(instruction.getLastError().contains("ledger offline"));
+        assertEquals(EpochStatus.NETTED, epoch.getStatus());
+        verify(outboxEventRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldFailInstructionWhenMaxAttemptsReached() {
+        EpochEntity epoch = epoch(12L, EpochStatus.NETTED);
+        SettlementInstructionEntity instruction = instruction(102L, SettlementStatus.RETRYING, 2, Instant.now().minusSeconds(1));
+        instruction.setEpoch(epoch);
+
+        when(settlementInstructionRepository.findByIdForUpdate(102L)).thenReturn(Optional.of(instruction));
+        when(epochRepository.findByIdForUpdate(12L)).thenReturn(Optional.of(epoch));
+        when(netPositionRepository.findByEpochIdOrderByIdAsc(12L)).thenReturn(List.of(
+                netPosition(epoch, participant(1L, "0x1111111111111111111111111111111111111111"), 0L)
+        ));
+        when(settlementLedgerClient.settle(eq(12L), org.mockito.ArgumentMatchers.<List<String>>any(), org.mockito.ArgumentMatchers.<List<Long>>any()))
+                .thenThrow(new IllegalStateException("contract revert"));
+
+        settlementProcessor.processInstruction(102L);
+
+        assertEquals(3, instruction.getAttemptCount());
+        assertEquals(SettlementStatus.FAILED, instruction.getStatus());
+        assertNull(instruction.getNextRetryAt());
+        assertTrue(instruction.getLastError().contains("contract revert"));
+        assertEquals(EpochStatus.FAILED, epoch.getStatus());
+        verify(outboxEventRepository, never()).save(any());
+    }
+
+    private SettlementInstructionEntity instruction(Long id, SettlementStatus status, int attempts, Instant nextRetryAt) {
+        SettlementInstructionEntity instruction = new SettlementInstructionEntity();
+        instruction.setId(id);
+        instruction.setStatus(status);
+        instruction.setAttemptCount(attempts);
+        instruction.setNextRetryAt(nextRetryAt);
+        return instruction;
+    }
+
+    private EpochEntity epoch(Long id, EpochStatus status) {
+        EpochEntity epoch = new EpochEntity();
+        epoch.setId(id);
+        epoch.setEpochNo(id);
+        epoch.setStatus(status);
+        return epoch;
+    }
+
+    private ParticipantEntity participant(Long id, String ledgerAddress) {
+        ParticipantEntity participant = new ParticipantEntity();
+        participant.setId(id);
+        participant.setParticipantCode("P" + id);
+        participant.setLedgerAddress(ledgerAddress);
+        participant.setNetDebitCapKrw(200_000L);
+        return participant;
+    }
+
+    private NetPositionEntity netPosition(EpochEntity epoch, ParticipantEntity participant, long delta) {
+        NetPositionEntity position = new NetPositionEntity();
+        position.setEpoch(epoch);
+        position.setParticipant(participant);
+        position.setNetAmountKrw(delta);
+        return position;
+    }
+}

--- a/clearing-hub/src/test/java/com/austinhong22/krwstablehub/service/SettlementSchedulerTest.java
+++ b/clearing-hub/src/test/java/com/austinhong22/krwstablehub/service/SettlementSchedulerTest.java
@@ -1,0 +1,31 @@
+package com.austinhong22.krwstablehub.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementSchedulerTest {
+
+    @Mock
+    private SettlementProcessor settlementProcessor;
+
+    @Test
+    void shouldProcessPendingInstructionIds() {
+        SettlementScheduler scheduler = new SettlementScheduler(settlementProcessor);
+        when(settlementProcessor.findPendingInstructionIds(any(Instant.class))).thenReturn(List.of(10L, 11L));
+
+        scheduler.processPendingSettlements();
+
+        verify(settlementProcessor).processInstruction(10L);
+        verify(settlementProcessor).processInstruction(11L);
+    }
+}


### PR DESCRIPTION
### 변경 요약
## 1) Ledger 연동
- `org.web3j:core` 추가
- `SettlementLedgerClient` 신규 구현
  - `settle(uint256,address[],int256[])` ABI 인코딩
  - `RawTransactionManager` 전송
  - receipt polling
  - receipt status OK + `Settled` event topic 검증

## 2) 정산 처리/재시도
- `SettlementProcessor` 신규 구현
  - `CREATED` + due `RETRYING` 대상 처리
  - instruction/epoch pessimistic lock
  - `NETTED` epoch만 처리
  - attempt 증가, maxAttempts 초과 시 `FAILED`
  - 호출 전 `RETRYING` 상태 반영
  - participant -> ledger address 매핑 후 1 tx 정산 호출
  - 성공 시 instruction `SETTLED`, epoch `SETTLED`, outbox `PENDING`
  - 실패 시 `last_error` 기록 + `RETRYING` 유지(또는 max 도달 시 `FAILED`)
- `SettlementScheduler` 신규 구현(주기 실행)

## 3) API 응답 확장
- `/epochs/{id}` 응답에 아래 필드 추가
  - `settlementStatus`
  - `txHash`

## 4) 테스트
- `SettlementProcessorTest` 추가
- `SettlementSchedulerTest` 추가
- `EpochQueryServiceTest` 업데이트
- Spring context test mock 보강

### 검증 내역
- `./gradlew test` (각 atomic commit 후 실행, 모두 통과)
- E2E:
  - DB 기동, hardhat node/deploy, app 기동 후 obligation 전송
  - `GET /epochs/{id}`에서 `settlementStatus`, `txHash` 확인
  - hardhat 중단 시 `RETRYING` 확인
  - hardhat 재기동 후 `RETRYING -> SETTLED` 수렴 확인
  - outbox `EPOCH_SETTLED / PENDING` 생성 확인

### 주요 커밋
- `c2bb2fd` feat: add web3j settlement ledger client
- `c89aab3` feat: add settlement retry processor and scheduler
- `a7641c5` feat: expose settlement status and tx hash on epoch API
