### PR TITLE
[#11]feat: finalize portfolio demo scripts and reviewer runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,185 +1,152 @@
 # KRW Stable Hub PoC
 
-Multi-stablecoin clearing and final settlement proof of concept using MySQL, Spring Boot, and Hardhat.
+Portfolio-grade demo for multi-stablecoin clearing and final settlement:
+- idempotent obligation intake (`tx_id` uniqueness + request hash conflict protection)
+- Net Debit Cap risk control (`HELD`)
+- epoch-based multilateral netting (`net_positions`)
+- single on-chain settlement transaction per epoch (`SettlementVault.settle`)
+- retry convergence + outbox event emission
 
-## Architecture Overview
+## Architecture Summary
 
-- `clearing-hub`:
-  Spring Boot service for obligation intake, risk checks, epoch netting, and settlement orchestration.
-- `settlement-ledger`:
-  Hardhat workspace containing Solidity contracts for local final settlement (`SettlementVault`).
-- `docker-compose.yml`:
-  Local infrastructure for MySQL 8.4.
+- `clearing-hub` (Spring Boot 3 / Java 17):
+  - `POST /obligations`: intake + idempotency + risk decision (`ACCEPTED`/`HELD`)
+  - scheduler closes due epochs, runs netting, creates settlement instruction
+  - settlement scheduler submits one ledger tx per epoch and retries on failure
+  - `GET /epochs/{id}` returns epoch status, net positions, settlement status, tx hash
+- `settlement-ledger` (Hardhat + Solidity):
+  - `SettlementVault` contract validates net-zero deltas and emits `Settled(epochId)`
+- MySQL:
+  - source-of-truth tables: `obligations`, `epochs`, `net_positions`, `settlement_instructions`, `outbox_events`
 
-## Start MySQL
+## Prerequisites
 
-1. Start database:
+- Java 17+
+- Docker + Docker Compose
+- Node.js 20+ and npm
+- `curl`
+
+## Start The System (Reviewer Setup)
+
+Open separate terminals.
+
+1. Start MySQL:
    ```bash
    ./scripts/db-up.sh
    ```
-   MySQL is exposed on local port `3307` for this project.
-2. Confirm container status:
-   ```bash
-   docker ps --filter name=clearing-mysql
-   ```
-3. Stop database:
-   ```bash
-   ./scripts/db-down.sh
-   ```
 
-## Run Clearing Hub
-
-1. Start MySQL first:
-   ```bash
-   ./scripts/db-up.sh
-   ```
-2. Start Spring Boot:
-   ```bash
-   (cd clearing-hub && ./gradlew bootRun)
-   ```
-3. Verify actuator health:
-   ```bash
-   curl http://localhost:8080/actuator/health
-   ```
-   Expected response:
-   ```json
-   {"status":"UP"}
-   ```
-
-## Run Settlement Ledger (Hardhat)
-
-1. Install dependencies:
+2. Install Hardhat dependencies (first time only):
    ```bash
    (cd settlement-ledger && npm install)
    ```
-2. Start a local Hardhat chain:
+
+3. Start local chain:
    ```bash
    (cd settlement-ledger && npm run node)
    ```
-3. In another terminal, deploy `SettlementVault` to localhost:
+
+4. Deploy `SettlementVault` (new terminal):
    ```bash
    (cd settlement-ledger && npm run deploy:local)
    ```
-   Expected output includes:
-   - `Deployer: <address>`
-   - `SettlementVault: <address>`
+   Copy printed `SettlementVault: <address>`.
 
-### Environment Variables
-
-Keep secrets out of git and set values locally:
-- `SETTLEMENT_VAULT_ADDRESS`: deployed contract address used by `clearing-hub`
-- `LEDGER_OPERATOR_PRIVATE_KEY`: operator key used by settlement submission flows
-- `LEDGER_OPERATOR_ADDRESS` (optional for deploy script): constructor operator address; defaults to deployer when omitted
-
-## Obligation Intake Examples
-
-All examples below assume:
-- app is running on `localhost:8080`
-- seeded participants `A`, `B`, `C` are present
-
-1. Submit a new obligation:
+5. Configure env vars for `clearing-hub` (new terminal):
    ```bash
-   curl -i -X POST http://localhost:8080/obligations \
-     -H 'Content-Type: application/json' \
-     -d '{
-       "txId":"tx-1001",
-       "payer":"A",
-       "payee":"B",
-       "payAsset":"KRW",
-       "amount":50000
-     }'
+   export SETTLEMENT_VAULT_ADDRESS=<deployed-address>
+   export LEDGER_OPERATOR_PRIVATE_KEY=<hardhat-operator-private-key>
    ```
-   Expected: `HTTP/1.1 202 Accepted` with `status` = `ACCEPTED` (if cap is not exceeded).
+   Notes:
+   - Keep real values local only.
+   - `.env.example` is intentionally blank.
 
-2. Repeat the same `txId` with identical payload (idempotent):
+6. Start Spring Boot:
    ```bash
-   curl -i -X POST http://localhost:8080/obligations \
-     -H 'Content-Type: application/json' \
-     -d '{
-       "txId":"tx-1001",
-       "payer":"A",
-       "payee":"B",
-       "payAsset":"KRW",
-       "amount":50000
-     }'
+   (cd clearing-hub && ./gradlew bootRun)
    ```
-   Then verify only one row exists:
-   ```bash
-   docker exec -i clearing-mysql \
-     mysql -uroot -proot -D clearing \
-     -e "select tx_id, count(*) as cnt from obligations where tx_id='tx-1001' group by tx_id;"
-   ```
-   Expected: `cnt = 1`.
 
-3. Trigger `HELD` by lowering payer cap and sending a large obligation:
+7. Health check:
    ```bash
-   docker exec -i clearing-mysql \
-     mysql -uroot -proot -D clearing \
-     -e "update participants set net_debit_cap_krw=10000 where participant_code='A';"
+   curl -sS http://localhost:8080/actuator/health
    ```
-   ```bash
-   curl -i -X POST http://localhost:8080/obligations \
-     -H 'Content-Type: application/json' \
-     -d '{
-       "txId":"tx-1002",
-       "payer":"A",
-       "payee":"B",
-       "payAsset":"KRW",
-       "amount":50000
-     }'
-   ```
-   Expected: `HTTP/1.1 202 Accepted` with `status` = `HELD`.
+   Expected: `{"status":"UP"}`
 
-## Epoch Close And Netting Demo
+## Demo Scenarios
 
-The scheduler checks every 1 second and closes an epoch when its window ends.
-Default epoch window is 60 seconds (`CLEARING_EPOCH_SECONDS`, configurable via env var).
+All demo scripts are executable and use `curl` for API actions. Each script prints exact SQL/API checks to run next.
 
-1. Submit mixed `ACCEPTED` obligations in the same epoch:
-   ```bash
-   curl -s -X POST http://localhost:8080/obligations \
-     -H 'Content-Type: application/json' \
-     -d '{"txId":"tx-2001","payer":"A","payee":"B","payAsset":"KRW","amount":70000}'
-   curl -s -X POST http://localhost:8080/obligations \
-     -H 'Content-Type: application/json' \
-     -d '{"txId":"tx-2002","payer":"B","payee":"C","payAsset":"KRW","amount":20000}'
-   curl -s -X POST http://localhost:8080/obligations \
-     -H 'Content-Type: application/json' \
-     -d '{"txId":"tx-2003","payer":"C","payee":"A","payAsset":"KRW","amount":10000}'
-   ```
-2. Read the latest epoch id:
-   ```bash
-   docker exec -i clearing-mysql \
-     mysql -uroot -proot -D clearing \
-     -e "select id, epoch_no, status, opened_at, closed_at from epochs order by id desc limit 3;"
-   ```
-3. Wait until the epoch window closes (up to 60 seconds), then inspect epoch details:
-   ```bash
-   curl -s http://localhost:8080/epochs/{epochId}
-   ```
-   Expected:
-   - `status` = `NETTED`
-   - non-empty `netPositions`
-   - `settlementInstruction.status` = `CREATED`
-   - `settlementInstruction.txHash` = `null` (before final settlement execution)
+### 1) Idempotency
 
-### `GET /epochs/{epochId}` Response Shape
+```bash
+./scripts/demo_idempotency.sh
+```
 
-```json
-{
-  "epochId": 12,
-  "epochNo": 29384756,
-  "status": "NETTED",
-  "openedAt": "2026-02-23T08:30:00Z",
-  "closedAt": "2026-02-23T08:31:00Z",
-  "netPositions": [
-    {"participantCode": "A", "netAmountKrw": -60000},
-    {"participantCode": "B", "netAmountKrw": 50000},
-    {"participantCode": "C", "netAmountKrw": 10000}
-  ],
-  "settlementInstruction": {
-    "status": "CREATED",
-    "txHash": null
-  }
-}
+Shows:
+- same `txId` + same payload is replay-safe
+- same `txId` + different payload returns conflict
+
+### 2) Netting + 1 On-chain Tx
+
+```bash
+./scripts/demo_netting_1tx.sh
+```
+
+Shows:
+- accepted obligations netted at epoch close
+- one settlement instruction with tx hash
+- outbox event for settled epoch
+
+### 3) Risk Cap HOLD
+
+```bash
+./scripts/demo_risk_cap_hold.sh
+```
+
+Shows:
+- over-cap obligation is `HELD`
+- held items are excluded from final netting positions
+
+### 4) Failure + Retry Convergence
+
+Precondition: run `clearing-hub` with intentionally broken ledger connectivity (for example stop Hardhat, or use invalid settlement env vars), then run:
+
+```bash
+./scripts/demo_failure_retry.sh
+```
+
+Shows:
+- settlement instruction transitions through retries
+- `attempt_count` increments and `last_error` is populated
+- terminal state reaches `FAILED` after max attempts
+
+### Guided Portfolio Walkthrough
+
+```bash
+./scripts/demo_full.sh
+```
+
+Interactive by default. Use `--yes` for non-interactive run:
+
+```bash
+./scripts/demo_full.sh --yes
+```
+
+## Useful Verification Queries
+
+Latest epochs:
+
+```bash
+docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e "select id,epoch_no,status,opened_at,closed_at from epochs order by id desc limit 5;"
+```
+
+Settlement instructions:
+
+```bash
+docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e "select id,epoch_id,status,tx_hash,attempt_count,last_error,next_retry_at from settlement_instructions order by id desc limit 10;"
+```
+
+Outbox settled events:
+
+```bash
+docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e "select id,aggregate_id,event_type,status,available_at from outbox_events where aggregate_type='EPOCH' order by id desc limit 10;"
 ```

--- a/scripts/demo_failure_retry.sh
+++ b/scripts/demo_failure_retry.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_BASE_URL="${API_BASE_URL:-http://localhost:8080}"
+TX_PREFIX="tx-demo-retry-$(date +%s)"
+
+post() {
+  local payload="$1"
+  curl -sS -i -X POST "${API_BASE_URL}/obligations" \
+    -H 'Content-Type: application/json' \
+    -d "${payload}"
+}
+
+echo "[demo_failure_retry] API_BASE_URL=${API_BASE_URL}"
+echo "Precondition for this scenario: run clearing-hub with broken ledger connectivity (example: Hardhat node stopped, or invalid SETTLEMENT_VAULT_ADDRESS / LEDGER_OPERATOR_PRIVATE_KEY)."
+echo "When precondition is met, settlement should move CREATED -> RETRYING and eventually FAILED after max attempts."
+
+echo "[1/3] A -> B 90000"
+post "$(printf '{"txId":"%s-1","payer":"A","payee":"B","payAsset":"KRW","amount":90000}' "${TX_PREFIX}")"
+
+echo
+echo "[2/3] B -> C 30000"
+post "$(printf '{"txId":"%s-2","payer":"B","payee":"C","payAsset":"KRW","amount":30000}' "${TX_PREFIX}")"
+
+echo
+echo "[3/3] C -> A 60000"
+post "$(printf '{"txId":"%s-3","payer":"C","payee":"A","payAsset":"KRW","amount":60000}' "${TX_PREFIX}")"
+
+echo
+echo "Next checks (after epoch closes):"
+echo "- SQL (find target epoch id):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select id,epoch_no,status,opened_at,closed_at from epochs order by id desc limit 5;\""
+echo "- API (replace {epochId}; expect status NETTED or FAILED while retries are happening):"
+echo "  curl -sS ${API_BASE_URL}/epochs/{epochId}"
+echo "- SQL (watch retries):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select id,epoch_id,status,tx_hash,attempt_count,last_error,next_retry_at from settlement_instructions where epoch_id={epochId};\""
+echo "- SQL (expected in failure demo): attempt_count increments, last_error populated, final status FAILED when attempts exceed max."

--- a/scripts/demo_full.sh
+++ b/scripts/demo_full.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+API_BASE_URL="${API_BASE_URL:-http://localhost:8080}"
+AUTO_RUN="${1:-}"
+
+run_step() {
+  local title="$1"
+  local script_path="$2"
+
+  echo
+  echo "============================================================"
+  echo "${title}"
+  echo "============================================================"
+
+  if [[ "${AUTO_RUN}" == "--yes" ]]; then
+    "${script_path}"
+    return
+  fi
+
+  read -r -p "Run this step now? [y/N] " answer
+  case "${answer}" in
+    y|Y|yes|YES)
+      "${script_path}"
+      ;;
+    *)
+      echo "Skipped ${title}."
+      ;;
+  esac
+}
+
+echo "KRW Stable Hub Portfolio Demo (guided)"
+echo "API_BASE_URL=${API_BASE_URL}"
+echo
+echo "Before running scenarios, ensure these are already up:"
+echo "1) ./scripts/db-up.sh"
+echo "2) (cd settlement-ledger && npm run node)"
+echo "3) (cd settlement-ledger && npm run deploy:local)"
+echo "4) export SETTLEMENT_VAULT_ADDRESS=<deployed-address>"
+echo "5) export LEDGER_OPERATOR_PRIVATE_KEY=<hardhat-account-private-key>"
+echo "6) (cd clearing-hub && ./gradlew bootRun)"
+echo
+echo "For failure-retry scenario, restart clearing-hub with intentionally broken ledger settings or stop Hardhat first."
+
+run_step "Scenario 1: Idempotency" "${ROOT_DIR}/scripts/demo_idempotency.sh"
+run_step "Scenario 2: Netting + Single On-chain Settlement Tx" "${ROOT_DIR}/scripts/demo_netting_1tx.sh"
+run_step "Scenario 3: Risk Cap HOLD" "${ROOT_DIR}/scripts/demo_risk_cap_hold.sh"
+run_step "Scenario 4: Failure + Retry" "${ROOT_DIR}/scripts/demo_failure_retry.sh"
+
+echo
+echo "Guided demo finished. Use each script's printed SQL and /epochs/{id} checks for reviewer evidence."

--- a/scripts/demo_idempotency.sh
+++ b/scripts/demo_idempotency.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_BASE_URL="${API_BASE_URL:-http://localhost:8080}"
+TX_ID="tx-demo-idem-$(date +%s)"
+
+post() {
+  local payload="$1"
+  curl -sS -i -X POST "${API_BASE_URL}/obligations" \
+    -H 'Content-Type: application/json' \
+    -d "${payload}"
+}
+
+echo "[demo_idempotency] API_BASE_URL=${API_BASE_URL}"
+echo "[1/3] First request (expected 202, status ACCEPTED or HELD depending on risk state)"
+PAYLOAD_SAME="$(printf '{"txId":"%s","payer":"A","payee":"B","payAsset":"KRW","amount":50000}' "${TX_ID}")"
+post "${PAYLOAD_SAME}"
+
+echo
+echo "[2/3] Same txId + same payload (expected idempotent replay: 202 with same obligation)"
+post "${PAYLOAD_SAME}"
+
+echo
+echo "[3/3] Same txId + different payload (expected 409 IDEMPOTENCY_CONFLICT)"
+PAYLOAD_CONFLICT="$(printf '{"txId":"%s","payer":"A","payee":"B","payAsset":"KRW","amount":51000}' "${TX_ID}")"
+post "${PAYLOAD_CONFLICT}" || true
+
+echo
+echo "Next checks:"
+echo "- SQL (exactly one row for tx_id):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select id,tx_id,request_hash,status,epoch_id,amount_krw from obligations where tx_id='${TX_ID}';\""
+echo "- SQL (find latest epoch id):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select id,epoch_no,status,opened_at,closed_at from epochs order by id desc limit 5;\""
+echo "- API (replace {epochId}):"
+echo "  curl -sS ${API_BASE_URL}/epochs/{epochId}"

--- a/scripts/demo_netting_1tx.sh
+++ b/scripts/demo_netting_1tx.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_BASE_URL="${API_BASE_URL:-http://localhost:8080}"
+TX_PREFIX="tx-demo-net-$(date +%s)"
+
+post() {
+  local payload="$1"
+  curl -sS -i -X POST "${API_BASE_URL}/obligations" \
+    -H 'Content-Type: application/json' \
+    -d "${payload}"
+}
+
+echo "[demo_netting_1tx] API_BASE_URL=${API_BASE_URL}"
+echo "Submitting 3 ACCEPTED obligations in one epoch window."
+
+echo "[1/3] A -> B 70000"
+post "$(printf '{"txId":"%s-1","payer":"A","payee":"B","payAsset":"KRW","amount":70000}' "${TX_PREFIX}")"
+
+echo
+echo "[2/3] B -> C 20000"
+post "$(printf '{"txId":"%s-2","payer":"B","payee":"C","payAsset":"KRW","amount":20000}' "${TX_PREFIX}")"
+
+echo
+echo "[3/3] C -> A 10000"
+post "$(printf '{"txId":"%s-3","payer":"C","payee":"A","payAsset":"KRW","amount":10000}' "${TX_PREFIX}")"
+
+echo
+echo "Next checks (wait until epoch closes; default window is 60 seconds):"
+echo "- SQL (locate epoch ids):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select id,epoch_no,status,opened_at,closed_at from epochs order by id desc limit 5;\""
+echo "- API (replace {epochId}, expected eventually: status=SETTLED, settlementStatus=SETTLED, txHash not null):"
+echo "  curl -sS ${API_BASE_URL}/epochs/{epochId}"
+echo "- SQL (net positions for that epoch):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select epoch_id,participant_id,net_amount_krw from net_positions where epoch_id={epochId} order by id;\""
+echo "- SQL (single settlement instruction, one tx):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select id,epoch_id,status,tx_hash,attempt_count,last_error,next_retry_at from settlement_instructions where epoch_id={epochId};\""
+echo "- SQL (outbox event):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select id,aggregate_id,event_type,status,available_at from outbox_events where aggregate_type='EPOCH' and aggregate_id={epochId} order by id;\""

--- a/scripts/demo_risk_cap_hold.sh
+++ b/scripts/demo_risk_cap_hold.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_BASE_URL="${API_BASE_URL:-http://localhost:8080}"
+TX_PREFIX="tx-demo-risk-$(date +%s)"
+
+post() {
+  local payload="$1"
+  curl -sS -i -X POST "${API_BASE_URL}/obligations" \
+    -H 'Content-Type: application/json' \
+    -d "${payload}"
+}
+
+echo "[demo_risk_cap_hold] API_BASE_URL=${API_BASE_URL}"
+echo "Participant A seeded net_debit_cap_krw is 200000."
+
+echo "[1/2] Control request under cap (expected 202 with status ACCEPTED)"
+post "$(printf '{"txId":"%s-ok","payer":"A","payee":"B","payAsset":"KRW","amount":50000}' "${TX_PREFIX}")"
+
+echo
+echo "[2/2] Over-cap request (expected 202 with status HELD)"
+post "$(printf '{"txId":"%s-hold","payer":"A","payee":"B","payAsset":"KRW","amount":250000}' "${TX_PREFIX}")"
+
+echo
+echo "Next checks:"
+echo "- SQL (confirm one ACCEPTED and one HELD):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select id,tx_id,status,amount_krw,epoch_id from obligations where tx_id like '${TX_PREFIX}%' order by id;\""
+echo "- SQL (HELD obligations do not enter netting):"
+echo "  docker exec -i clearing-mysql mysql -uroot -proot -D clearing -e \"select o.tx_id,o.status,np.net_amount_krw from obligations o left join net_positions np on np.epoch_id=o.epoch_id where o.tx_id like '${TX_PREFIX}%';\""
+echo "- API (replace {epochId} from SQL):"
+echo "  curl -sS ${API_BASE_URL}/epochs/{epochId}"


### PR DESCRIPTION

## Summary
포트폴리오 데모 마무리를 위해 시나리오 실행 스크립트와 README 런북을 정리했습니다.

## Changes
- Add executable demo scripts:
  - `scripts/demo_idempotency.sh`
  - `scripts/demo_netting_1tx.sh`
  - `scripts/demo_risk_cap_hold.sh`
  - `scripts/demo_failure_retry.sh`
  - `scripts/demo_full.sh` (interactive guided run)
- Each scenario script:
  - uses `curl` for API actions
  - prints what to check next (`/epochs/{id}`, SQL queries)
- Finalize `README.md`:
  - prerequisites
  - startup sequence (DB -> hardhat -> deploy -> env -> spring)
  - 4 demo scenarios
  - concise architecture summary

## Verification
- `bash -n scripts/demo_idempotency.sh scripts/demo_netting_1tx.sh scripts/demo_risk_cap_hold.sh`
- `bash -n scripts/demo_idempotency.sh scripts/demo_netting_1tx.sh scripts/demo_risk_cap_hold.sh scripts/demo_failure_retry.sh scripts/demo_full.sh`
- `rg -n "^## (Prerequisites|Start The System|Demo Scenarios|Architecture Summary)|demo_(idempotency|netting_1tx|risk_cap_hold|failure_retry|full)" README.md`
- `ls -l scripts/demo_*.sh`

## Notes
- 통합 실행(DB/Hardhat/Spring up 상태에서의 end-to-end)은 로컬 런타임 환경에서 수행 필요
